### PR TITLE
Add branch protection guidance and automation

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -9,8 +9,12 @@ branches:
         contexts:
           - lint
           - test
+          - build
       required_pull_request_reviews: true
-      enforce_admins: true
+      enforce_admins: false
       required_linear_history: true
       allow_force_pushes: false
       allow_deletions: false
+      bypass_pull_request_allowances:
+        apps:
+          - dependabot

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,8 @@ Once your changes are pushed:
 - Stick to existing folder and naming conventions
 - Keep code modular, clean, and minimal where possible
 
+### Branch Protection
+Main branch is protected. All changes require pull requests with passing `lint`, `test`, and `build` checks. Force pushes and deletions are disabled and linear history is enforced. Repository admins and Dependabot can bypass these rules. See [docs/branch-protection.md](docs/branch-protection.md) for details.
 ---
 
 ## 💖 What We Value

--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ You can also spin up a ready-to-go development container with VS Code:
 ```bash
 # Requires Docker and the VS Code Dev Containers extension
 devcontainer open .
+
 ```
 
+🔒 To apply branch protection rules, run `./scripts/setup-branch-protection.sh` or follow the guide in `docs/branch-protection.md`.
 ---
 
 ## 🤝 Contributing

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,0 +1,32 @@
+# Branch Protection Rules
+
+This project uses a standard branch protection ruleset to keep `main` safe and the history clean.
+
+## Purpose
+
+Branch protection ensures that important checks run before code is merged. It prevents force pushes and accidental deletions so that the integrity of the main branch is preserved.
+
+## Who Can Bypass
+
+Repository administrators and the **Dependabot** app are allowed to bypass the restrictions. This keeps regular development strict while still letting security updates and admin fixes through when needed.
+
+## Why Each Rule Exists
+
+- **Require pull requests before merging** – encourages code review and keeps history clear.
+- **Require status checks** (`lint`, `test`, `build`) – only merge code that passes automated quality gates.
+- **Prevent force pushes and deletions** – protects the branch from accidental damage.
+- **Require linear history** – keeps git log readable and avoids merge bubbles.
+
+## Manual Setup in GitHub UI
+
+1. Go to your repository on GitHub.
+2. Navigate to **Settings** → **Branches** → **Branch protection rules**.
+3. Create a rule for the `main` branch.
+4. Enable:
+   - "Require a pull request before merging"
+   - "Require status checks to pass before merging" and select `lint`, `test`, `build`
+   - "Require linear history"
+   - Disable force pushes and branch deletions
+5. Under **Branch protection rule exceptions**, add your repository administrators and the **Dependabot** app.
+
+For more details see [GitHub Docs: Managing Branch Protection Rules](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branch-protection-rules).

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Apply branch protection rules using GitHub CLI
+# Requires: gh CLI authenticated with repo scope
+
+set -euo pipefail
+
+if ! command -v gh &>/dev/null; then
+  echo "gh CLI is required" >&2
+  exit 1
+fi
+
+OWNER_REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+BRANCH="main"
+
+# JSON payload for the branch protection API
+read -r -d '' PAYLOAD <<JSON
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["lint", "test", "build"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1
+  },
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "bypass_pull_request_allowances": {
+    "apps": ["dependabot"],
+    "users": []
+  }
+}
+JSON
+
+# Apply protection
+gh api -X PUT "repos/$OWNER_REPO/branches/$BRANCH/protection" --input - <<<"$PAYLOAD"
+
+echo "Branch protection applied to $BRANCH"
+


### PR DESCRIPTION
## Summary
- document branch protection setup in `docs/branch-protection.md`
- provide `scripts/setup-branch-protection.sh` for automatic rules
- mention branch protection in CONTRIBUTING guide
- note setup step in README Getting Started section
- configure `.github/settings.yml` with lint/test/build checks and Dependabot bypass

## Testing
- `bash scripts/test.sh`
- `bash scripts/setup.sh`