### PR TITLE
docs: add convention documentation system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,8 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - id: pr_title_check
+        uses: amannn/action-semantic-pull-request@v5
         if: github.repository == 'PtiCalin/temp_repo-gen'
         continue-on-error: true
         with:
@@ -37,3 +38,6 @@ jobs:
             chore
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Commit format help
+        if: steps.pr_title_check.outcome == 'failure'
+        run: echo "Please see docs/conventions/commit-format.md" && exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,17 @@ This repo is built on curiosity, creativity, and care — and *you* are part of 
 
 ---
 
+## 📚 Project Conventions
+
+To keep code and structure consistent across teams and clones, this project follows a unified set of internal conventions:
+
+- 🔤 [Naming Rules](docs/conventions/naming.md)
+- 🗂️ [Folder Structure](docs/conventions/folder-structure.md)
+- 🧼 [Code Style Guide](docs/conventions/code-style.md)
+- 📝 [Commit Format](docs/conventions/commit-format.md)
+
+All PRs and CI checks rely on these conventions. You don’t have to memorize them — they’re embedded into the automation too 💜
+
 ## 🧩 Ways to Contribute
 
 🪄 Whether you're a coder, documenter, designer, or dreamer — here are some great ways to help:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ This repo is designed for smooth setup, clear structure, and joyful tinkering.
 
 ## 🚀 Getting Started
 
+📚 View coding conventions and architecture docs in `/docs/conventions`
+
 Clone this repo and start building:
 
 ```bash

--- a/docs/conventions/code-style.md
+++ b/docs/conventions/code-style.md
@@ -1,0 +1,20 @@
+# \ud83c\udfbc Code Style
+
+This repo assumes use of automated formatters:
+- JS/TS: Prettier + ESLint
+- Python: Black + Ruff
+- Markdown/YAML/JSON: Prettier
+
+### Formatting Rules
+
+- Use 2-space indentation
+- Trailing commas where supported
+- Semicolons for JS/TS
+- Single quotes preferred
+- Always use brackets `{}` for blocks
+- Annotate non-obvious logic
+
+### Automation
+
+- Run `scripts/verify-setup.sh` to install all linters and formatters
+- CI will fail if linting or formatting fails

--- a/docs/conventions/commit-format.md
+++ b/docs/conventions/commit-format.md
@@ -1,0 +1,25 @@
+# \ud83d\udcdd Conventional Commits
+
+Required for CI to pass PR title check.
+
+## Format
+
+<type>: <short summary>
+
+Example:
+feat: add api endpoint for user auth
+
+### Valid Types
+
+- `feat`: New feature
+- `fix`: Bug fix
+- `docs`: Documentation only
+- `style`: Code style change (no logic)
+- `refactor`: Internal code changes
+- `chore`: Build process or tools
+- `test`: Adding or fixing tests
+
+### Notes
+
+- PR titles **must** match this format
+- Commit messages may contain longer body and footer sections (optional)

--- a/docs/conventions/folder-structure.md
+++ b/docs/conventions/folder-structure.md
@@ -1,0 +1,25 @@
+# \ud83d\udcc1 Folder Structure Convention
+
+This template follows a modular structure designed for scale, clarity, and automation.
+
+## Root-level Layout
+
+| Folder/File         | Purpose |
+|---------------------|---------|
+| `/scripts`          | CLI tools, init scripts, CI helpers |
+| `/utils`            | Code-generating, formatter, and tool functions |
+| `/packages`         | Monorepo-style packages (auto-published) |
+| `.github/`          | GitHub Actions, issue/PR templates, labels, settings |
+| `/docs`             | Internal developer documentation and conventions |
+
+## Example `packages/` layout
+
+```
+packages/
+├── api/
+│   ├── src/
+│   └── package.json
+└── ui/
+    ├── src/
+    └── package.json
+```

--- a/docs/conventions/naming.md
+++ b/docs/conventions/naming.md
@@ -1,0 +1,22 @@
+# \ud83c\uddf4 Naming Conventions
+
+## General Principles
+
+- \u2705 Prefer clarity over brevity
+- \ud83e\uddfa Use kebab-case for files and folders
+- \ud83e\uddea Use PascalCase for component names and classes
+- \ud83d\udd27 Use camelCase for functions and variables
+- \ud83d\udd11 Environment variables: `ALL_CAPS_SNAKE_CASE`
+
+## Branches
+
+- `feat/short-description`
+- `fix/bug-identifier`
+- `chore/tooling-update`
+- `release/x.y.z`
+
+## GitHub Workflows
+
+- `ci.yml` = core CI tests
+- `pr-tracker.yml` = links PRs to issues
+- `publish-package.yml` = deploys `packages/*` to GitHub Packages

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+# Documentation Index
+
+- [Changelog](CHANGELOG.md)
+- [Branch Protection](branch-protection.md)
+- **Conventions**
+  - [Folder Structure](conventions/folder-structure.md)
+  - [Naming Rules](conventions/naming.md)
+  - [Code Style](conventions/code-style.md)
+  - [Commit Format](conventions/commit-format.md)


### PR DESCRIPTION
## Summary
- document folder structure, naming, code style and commit format
- link docs from `CONTRIBUTING.md` and `README.md`
- add docs index
- show helpful hint on PR title CI failure

## Testing
- `./scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68729d09df608322b8d45b32ed686234