### PR TITLE
feat: add GitHub project automation

### DIFF
--- a/.github/project-config.json
+++ b/.github/project-config.json
@@ -1,0 +1,6 @@
+{
+  "title": "Repo Project",
+  "project_url": "https://github.com/users/PtiCalin/projects/1",
+  "status_field_id": "STATUS_FIELD_ID",
+  "done_option_id": "DONE_OPTION_ID"
+}

--- a/.github/workflows/project-link.yml
+++ b/.github/workflows/project-link.yml
@@ -1,0 +1,21 @@
+name: Add Items to Project
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read config
+        run: echo "PROJECT_URL=$(jq -r .project_url .github/project-config.json)" >> $GITHUB_ENV
+      - uses: actions/add-to-project@v1
+        with:
+          project-url: ${{ env.PROJECT_URL }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          status: "To Do"
+

--- a/.github/workflows/project-status.yml
+++ b/.github/workflows/project-status.yml
@@ -1,0 +1,44 @@
+name: Update Project Status
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  mark-done:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update status
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const config = JSON.parse(fs.readFileSync('.github/project-config.json', 'utf8'));
+            const prId = context.payload.pull_request.node_id;
+            const query = await github.graphql(`
+              query($owner:String!,$repo:String!,$pr:Int!){
+                repository(owner:$owner,name:$repo){
+                  pullRequest(number:$pr){
+                    projectItems(first:1){ nodes { id } }
+                  }
+                }
+              }
+            `, {owner: context.repo.owner, repo: context.repo.repo, pr: context.payload.pull_request.number});
+            const itemId = query.repository.pullRequest.projectItems.nodes[0].id;
+            await github.graphql(`
+              mutation($project:String!,$item:String!,$field:String!,$option:String!){
+                updateProjectV2ItemFieldValue(input:{projectId:$project,itemId:$item,fieldId:$field,value:{singleSelectOptionId:$option}}){
+                  clientMutationId
+                }
+              }
+            `, {project: config.project_url.split('/').pop(), item: itemId, field: config.status_field_id, option: config.done_option_id});
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: '🎉 Status set to Done'
+            });
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,9 @@ To keep code and structure consistent across teams and clones, this project foll
 
 All PRs and CI checks rely on these conventions. You don’t have to memorize them — they’re embedded into the automation too 💜
 
+### Project Board
+Issues and pull requests are automatically added to the project board. Status updates happen when PRs merge so you can track progress at a glance.
+
 ## 🧩 Ways to Contribute
 
 🪄 Whether you're a coder, documenter, designer, or dreamer — here are some great ways to help:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repo is designed for smooth setup, clear structure, and joyful tinkering.
 - 📜 MIT License included  
 - 🧭 Custom issue and pull request templates  
 - 💬 GitHub Discussions enabled
+- 🏁 This template auto-connects your issues and PRs to a GitHub Project board for sprint-style tracking
 - 💖 Sponsor link to support creative tooling
 - 🐳 Ready-to-use [devcontainer](./.devcontainer) for VS Code
 - 🛡️ Automatic dependency updates via Dependabot

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,7 @@
 
 - [Changelog](CHANGELOG.md)
 - [Branch Protection](branch-protection.md)
+- [Project Board Automation](projects.md)
 - **Conventions**
   - [Folder Structure](conventions/folder-structure.md)
   - [Naming Rules](conventions/naming.md)

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -1,0 +1,5 @@
+# Project Board Automation
+
+This template sets up a GitHub Project board automatically. Issues and pull requests are added to the board when they are opened. When a pull request is merged, its project item is moved to **Done**.
+
+The project configuration lives in `.github/project-config.json` and can be tweaked for your workflow. Run `./scripts/setup-project.sh` to create a board with default fields and views.

--- a/scripts/setup-project.sh
+++ b/scripts/setup-project.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gh >/dev/null; then
+  echo "gh CLI is required" >&2
+  exit 1
+fi
+
+config=".github/project-config.json"
+
+if [[ ! -f "$config" ]]; then
+  echo "{}" > "$config"
+fi
+
+project_title=$(jq -r '.title // "Repo Project"' "$config")
+
+# Create project and capture ID
+project_json=$(gh project create --title "$project_title" --format json)
+project_id=$(echo "$project_json" | jq -r '.id')
+
+# Add default fields
+gh project field-create "$project_id" --name "Status" --data-type SINGLE_SELECT > /dev/null
+gh project field-create "$project_id" --name "Type" --data-type SINGLE_SELECT > /dev/null
+gh project field-create "$project_id" --name "Linked Issue" --data-type ISSUE > /dev/null
+
+# Add default views
+gh project view-create "$project_id" --name "Board" --layout BOARD > /dev/null
+gh project view-create "$project_id" --name "Table" --layout TABLE > /dev/null
+
+echo "Project $project_title created with ID $project_id"


### PR DESCRIPTION
## Summary
- automate linking issues and PRs to a GitHub Project board
- update project item status on merge
- bootstrap project boards via script
- document project board automation
- mention project board in README and CONTRIBUTING

## Testing
- `./scripts/test.sh`
- `./scripts/setup.sh`