### PR TITLE
Add auto wiki integration

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,8 @@
 ## 🧠 Summary
 Briefly describe what this PR does and why it matters.
 
+For deeper context, see the [Architecture wiki](../../wiki/Architecture).
+
 - ✨ Feature:
 - 🐛 Bugfix:
 - 🧹 Refactor:

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,0 +1,23 @@
+name: sync-wiki
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'wiki-starter/**'
+      - '.github/workflows/sync-wiki.yml'
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+      - name: Sync wiki
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+        run: |
+          ./scripts/init-wiki.sh "$OWNER" "$REPO"

--- a/.github/workflows/wiki-check.yml
+++ b/.github/workflows/wiki-check.yml
@@ -1,0 +1,24 @@
+name: wiki-check
+on:
+  pull_request:
+    paths:
+      - 'wiki-starter/**'
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Compare wiki contents
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git clone https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.wiki.git wiki
+          cp wiki-starter/*.md wiki/
+          cd wiki
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "Wiki is out of sync. Run scripts/init-wiki.sh" >&2
+            git status --porcelain
+            exit 1
+          else
+            echo "Wiki up to date"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 .vscode/
 !.vscode/settings.json
 .DS_Store
+*.wiki.git/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,9 @@
 # ✨ Contributing Guide
 
-Thank you for considering a contribution to this project!  
+Thank you for considering a contribution to this project!
 This repo is built on curiosity, creativity, and care — and *you* are part of that magic.
+
+For detailed setup steps and architecture decisions, visit the [project wiki](../../wiki).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ Initialize default issue labels:
 ./scripts/init-labels.sh
 ```
 
+## 📚 Project Wiki
+
+This project includes a companion [GitHub Wiki](../../wiki) with extended documentation:
+- Setup Guide
+- Architecture Diagrams
+- Contribution Guide
+- Terminology Glossary
+
 ---
 
 ## 📦 Package Publishing

--- a/scripts/init-wiki.sh
+++ b/scripts/init-wiki.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# ───────────────────────────────────────────────────────────────
+# 📚 Initialize GitHub Wiki with starter pages
+# Copies files from /wiki-starter into the repo's wiki repository
+# Requires: git and a token with push access
+# Usage: ./scripts/init-wiki.sh <owner> <repo>
+# ───────────────────────────────────────────────────────────────
+set -euo pipefail
+
+OWNER=${1:-""}
+REPO=${2:-""}
+
+if [[ -z "$OWNER" || -z "$REPO" ]]; then
+  echo "Usage: $0 <owner> <repo>"
+  exit 1
+fi
+
+WIKI_URL="https://github.com/${OWNER}/${REPO}.wiki.git"
+CLONE_URL="$WIKI_URL"
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  CLONE_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${OWNER}/${REPO}.wiki.git"
+fi
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "📚 Cloning wiki repo..."
+ git clone "$CLONE_URL" "$TMP_DIR"
+
+cp wiki-starter/*.md "$TMP_DIR"/
+
+cd "$TMP_DIR"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  git add .
+  git commit -m "feat: initialize wiki" || true
+  echo "🚀 Pushing wiki pages..."
+  git push origin master
+else
+  echo "✅ Wiki already up to date"
+fi

--- a/wiki-starter/Architecture.md
+++ b/wiki-starter/Architecture.md
@@ -1,0 +1,5 @@
+# 🏗️ Architecture
+
+Overview of the system design, file structure, and key decisions.
+
+Back to [Home](Home).

--- a/wiki-starter/Changelog.md
+++ b/wiki-starter/Changelog.md
@@ -1,0 +1,5 @@
+# 📝 Changelog
+
+Manual record of notable changes by version.
+
+Back to [Home](Home).

--- a/wiki-starter/Contributing.md
+++ b/wiki-starter/Contributing.md
@@ -1,0 +1,5 @@
+# 🤝 Contributing
+
+Etiquette, CI guidelines, and naming conventions.
+
+Back to [Home](Home).

--- a/wiki-starter/Glossary.md
+++ b/wiki-starter/Glossary.md
@@ -1,0 +1,5 @@
+# 📖 Glossary
+
+Common domain terms and concepts.
+
+Back to [Home](Home).

--- a/wiki-starter/Home.md
+++ b/wiki-starter/Home.md
@@ -1,0 +1,3 @@
+# 🏠 Welcome to the Wiki
+
+This wiki complements the main [repository](../). Navigate using the sidebar for architecture, setup, and more.

--- a/wiki-starter/Setup.md
+++ b/wiki-starter/Setup.md
@@ -1,0 +1,5 @@
+# ⚙️ Setup Guide
+
+Instructions for installing and using the project.
+
+Back to [Home](Home).


### PR DESCRIPTION
## Summary
- seed new `wiki-starter` directory with default wiki pages
- add `scripts/init-wiki.sh` for pushing pages to a repo wiki
- link wiki from README, CONTRIBUTING, and PR template
- ignore local `*.wiki.git` folders
- add actions to sync wiki and verify wiki contents

## Testing
- `./scripts/lint.sh` *(fails: shellcheck missing)*
- `./scripts/test.sh`